### PR TITLE
Add support for Linux and macOS

### DIFF
--- a/src/Phosphor/Cmdlets/ShowModuleCmdlet.cs
+++ b/src/Phosphor/Cmdlets/ShowModuleCmdlet.cs
@@ -3,7 +3,9 @@
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 //
 
+using System.Diagnostics;
 using System.Management.Automation;
+using System.Runtime.InteropServices;
 using Microsoft.PowerShell.Phosphor.Model;
 
 namespace Microsoft.PowerShell.Phosphor
@@ -29,9 +31,26 @@ namespace Microsoft.PowerShell.Phosphor
                 SessionManager.Current.StartSession(
                     new ModuleViewModel(commandList));
 
-            // TODO: This needs to be modified for Linux and macOS
-            // Example: https://github.com/PowerShell/PowerShell/blob/7f83c48ca5e39bc98dbb9071d414bd02166cd4af/src/System.Management.Automation/help/HelpCommands.cs#L635
-            System.Diagnostics.Process.Start(this.currentSession.Uri.AbsoluteUri);
+            Process browserProcess = new Process();
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                browserProcess.StartInfo.FileName = "xdg-open";
+                browserProcess.StartInfo.Arguments = this.currentSession.Uri.AbsoluteUri;
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                browserProcess.StartInfo.FileName = "open";
+                browserProcess.StartInfo.Arguments = this.currentSession.Uri.AbsoluteUri;
+            }
+            else
+            {
+                // TODO: This won't work on Windows when running in CoreCLR.  See this
+                // code in PowerShell Core:
+                // https://github.com/PowerShell/PowerShell/blob/7f83c48ca5e39bc98dbb9071d414bd02166cd4af/src/System.Management.Automation/engine/Utils.cs#L1608
+                browserProcess.StartInfo.FileName = this.currentSession.Uri.AbsoluteUri;
+            }
+
+            browserProcess.Start();
         }
     }
 }

--- a/src/Phosphor/Server/PhosphorServer.cs
+++ b/src/Phosphor/Server/PhosphorServer.cs
@@ -31,8 +31,8 @@ namespace Microsoft.PowerShell.Phosphor
             var clientPath =
                 Path.GetFullPath(
                     Path.Combine(
-                        Path.GetDirectoryName(this.GetType().Assembly.Location),
-                        "..\\..\\..\\..\\..\\Phosphor.Client\\"));
+                        Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location),
+                        "../../../../../Phosphor.Client/"));
 
 #if NETSTANDARD1_6
             AssemblyLoadContext.Default.Resolving += this.OnAssemblyResolve;
@@ -80,7 +80,7 @@ namespace Microsoft.PowerShell.Phosphor
 #endif
             try
             {
-                if (assemblyNameString.StartsWith("Phosphor.Server"))
+                if (assemblyNameString.StartsWith("Phosphor"))
                 {
                     return this.GetType().GetTypeInfo().Assembly;
                 }
@@ -102,6 +102,5 @@ namespace Microsoft.PowerShell.Phosphor
 
             return null;
         }
-
     }
 }

--- a/src/Phosphor/Server/PhosphorServerStartup.cs
+++ b/src/Phosphor/Server/PhosphorServerStartup.cs
@@ -4,6 +4,7 @@
 //
 
 using System.IO;
+using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -41,8 +42,8 @@ namespace Microsoft.PowerShell.Phosphor
             var clientPath =
                 Path.GetFullPath(
                     Path.Combine(
-                        Path.GetDirectoryName(this.GetType().Assembly.Location),
-                        "..\\..\\..\\..\\..\\Phosphor.Client\\"));
+                        Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location),
+                        "../../../../../Phosphor.Client/"));
 
             app.UseFileServer(new FileServerOptions()
             {


### PR DESCRIPTION
This change enables support for Linux and macOS by fixing up the minor issues preventing Phosphor from running on those platforms.