### PR TITLE
Introduce Electron as desktop shell for the web UI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/src/Phosphor.Client/electron-shell.js
+++ b/src/Phosphor.Client/electron-shell.js
@@ -1,0 +1,33 @@
+const electron = require('electron')
+const app = electron.app
+const BrowserWindow = electron.BrowserWindow
+
+const path = require('path')
+
+let mainWindow
+
+function createWindow () {
+  mainWindow = new BrowserWindow({width: 800, height: 600})
+
+  mainWindow.loadURL(process.argv[2]);
+
+  // mainWindow.webContents.openDevTools()
+
+  mainWindow.on('closed', function () {
+    mainWindow = null
+  })
+}
+
+app.on('ready', createWindow)
+
+app.on('window-all-closed', function () {
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', function () {
+  if (mainWindow === null) {
+    createWindow()
+  }
+})

--- a/src/Phosphor.Client/package.json
+++ b/src/Phosphor.Client/package.json
@@ -12,29 +12,28 @@
   },
   "license": "ISC",
   "dependencies": {
-    "@angular/common":  "2.0.0-rc.1",
-    "@angular/compiler":  "2.0.0-rc.1",
-    "@angular/core":  "2.0.0-rc.1",
-    "@angular/http":  "2.0.0-rc.1",
-    "@angular/platform-browser":  "2.0.0-rc.1",
-    "@angular/platform-browser-dynamic":  "2.0.0-rc.1",
-    "@angular/router":  "2.0.0-rc.1",
-    "@angular/router-deprecated":  "2.0.0-rc.1",
-    "@angular/upgrade":  "2.0.0-rc.1",
-
+    "@angular/common": "2.0.0-rc.1",
+    "@angular/compiler": "2.0.0-rc.1",
+    "@angular/core": "2.0.0-rc.1",
+    "@angular/http": "2.0.0-rc.1",
+    "@angular/platform-browser": "2.0.0-rc.1",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.1",
+    "@angular/router": "2.0.0-rc.1",
+    "@angular/router-deprecated": "2.0.0-rc.1",
+    "@angular/upgrade": "2.0.0-rc.1",
     "systemjs": "0.19.27",
     "core-js": "^2.4.0",
     "reflect-metadata": "^0.1.3",
     "rxjs": "5.0.0-beta.6",
     "zone.js": "^0.6.12",
-
     "angular2-in-memory-web-api": "0.0.11",
     "bootstrap": "^3.3.6"
   },
   "devDependencies": {
     "concurrently": "^2.0.0",
+    "electron": "^1.6.2",
     "lite-server": "^2.2.0",
     "typescript": "^2.0.0",
-    "typings":"^1.0.4"
+    "typings": "^1.0.4"
   }
 }

--- a/src/Phosphor/Session/PhosphorSession.cs
+++ b/src/Phosphor/Session/PhosphorSession.cs
@@ -4,12 +4,16 @@
 //
 
 using System;
+using System.IO;
+using System.Reflection;
 using Microsoft.PowerShell.Phosphor.Model;
 
 namespace Microsoft.PowerShell.Phosphor
 {
     public class PhosphorSession
     {
+        private static string ClientPath;
+
         public int Id { get; private set; }
 
         public Uri Uri { get; private set; }
@@ -24,6 +28,20 @@ namespace Microsoft.PowerShell.Phosphor
             this.Id = sessionId;
             this.Uri = new Uri(serverBaseUri, $"?session={sessionId}");
             this.Model = model;
+        }
+
+        public string GetClientPath(string subPath = "")
+        {
+            if (ClientPath == null)
+            {
+                ClientPath =
+                    Path.GetFullPath(
+                        Path.Combine(
+                            Path.GetDirectoryName(this.GetType().GetTypeInfo().Assembly.Location),
+                            "../../../../../Phosphor.Client/"));
+            }
+
+            return Path.Combine(ClientPath, subPath);
         }
     }
 }


### PR DESCRIPTION
This change adds the Electron desktop application shell so that the
Phosphor web UI can be hosted there by default.  This provides a more
desktop-like experience when launching Show-Module from the command
line.  An -OpenInBrowser parameter was also added to Show-Module to
allow opening the web UI in a browser in cases where that is desirable.