### PR TITLE
Add missing package source for dependencies.

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,5 +2,6 @@
 <configuration>
   <packageSources>
     <add key="powershell-core" value="https://powershell.myget.org/F/powershell-core/api/v3/index.json" />
+    <add key="dotnet-core" value="https://www.myget.org/F/dotnet-core/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Needed for Microsoft.NETCore.Portable.Compatibility package.