### PR TITLE
Changed PowerShell to lowercase for compiling on a Mac

### DIFF
--- a/Phosphor.build.ps1
+++ b/Phosphor.build.ps1
@@ -143,7 +143,7 @@ task UploadArtifacts -If ($script:IsCIBuild) {
 }
 
 task RunModule Build, {
-   PowerShell -NoProfile -NoExit -Command {
+   powershell -NoProfile -NoExit -Command {
         param($repoPath)
 
         function prompt {


### PR DESCRIPTION
Ran into some trouble trying to run PowerShell on a Mac.
Running powershell in all lowercase worked...

Here's a screenshot trying to run PowerShell from terminal:
![screen shot 2017-05-08 at 21 13 44](https://cloud.githubusercontent.com/assets/10112589/25822345/a268c584-3438-11e7-86b4-498ec439781e.png)
